### PR TITLE
ccure employee id

### DIFF
--- a/src/main/groovy/com/cloudcard/photoDownloader/CloudCardClient.groovy
+++ b/src/main/groovy/com/cloudcard/photoDownloader/CloudCardClient.groovy
@@ -13,9 +13,6 @@ import java.nio.charset.StandardCharsets
 
 import jakarta.annotation.PostConstruct
 
-import static com.cloudcard.photoDownloader.ApplicationPropertiesValidator.throwIfBlank
-
-
 @Component
 class CloudCardClient {
 
@@ -54,12 +51,12 @@ class CloudCardClient {
         return apiUrl && tokenService.isConfigured()
     }
 
-    Person createPerson(String email) {
+    Person createPerson(String email, String identifier) {
         String url = "${apiUrl}/people"
 
         HttpResponse<String> response = Unirest.post(url)
                 .headers(standardHeaders())
-                .body("{ \"email\": \"${email}\" }")
+                .body("{ \"email\": \"${email}\", \"identifier\": \"${identifier}\" }")
                 .asString()
 
         if (response.status != 201) {
@@ -70,8 +67,16 @@ class CloudCardClient {
         return new ObjectMapper().readValue(response.body, new TypeReference<Person>() {})
     }
 
-    Person findPerson(String email) {
-        String url = "${apiUrl}/people/${email}?findBy=email"
+    Person findPersonByIdentifier(String id) {
+        return findPerson(id, "identifier")
+    }
+
+    Person findPersonByEmail(String email) {
+        return findPerson(email, "email")
+    }
+
+    Person findPerson(String identifier, String findBy) {
+        String url = "${apiUrl}/people/${identifier}?findBy=${findBy}"
 
         HttpResponse<String> response = Unirest.get(url)
                 .headers(standardHeaders())
@@ -79,7 +84,7 @@ class CloudCardClient {
 
         if (response.status != 200) {
             if (response.status >= 500) {
-                log.error("Status ${response.status} returned from CloudCard API when finding person: ${email}")
+                log.error("Status ${response.status} returned from CloudCard API when finding person: ${identifier}")
             }
             return null
         }

--- a/src/main/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureClient.groovy
+++ b/src/main/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureClient.groovy
@@ -155,7 +155,7 @@ class CCureClient {
         }
     }
 
-    Long createPersonnel(String firstName, String lastName, String email) {
+    Long createPersonnel(String firstName, String lastName, String email, String employeeId) {
         if (!firstName || !lastName) {
             log.warn("First/Last Name fields were missing for $email; unable to create CCURE Personnel")
             return null
@@ -171,6 +171,8 @@ class CCureClient {
                     .field("PropertyValues[1]", lastName)
                     .field("PropertyNames[2]", "EmailAddress")
                     .field("PropertyValues[2]", email)
+                    .field("PropertyNames[3]", employeeIdField)
+                    .field("PropertyValues[3]", employeeId)
                     .asString()
         } as HttpResponse<String>
 
@@ -308,6 +310,25 @@ class CCureClient {
      * @param guid
      * @return
      */
+    CCurePersonnel getPersonnelDetails(String id, String email) {
+        CCurePersonnel result = getPersonnelDetailsByEmployeeId(id)
+        if (!result) {
+            result = getPersonnelDetailsByEmail(email)
+        }
+
+        return result
+    }
+
+    CCurePersonnel getPersonnelDetailsByEmployeeId(String id) {
+        MultipartBody request = Unirest.post(apiUrl + "/Objects/FindObjsWithCriteriaFilter")
+                .field("TypeFullName", CCurePersonnel.TYPE)
+                .field("whereClause", "$employeeIdField = ?")
+                .field("arguments[]", id) // ArgTypes[] is not required for standard string comparisons
+                .field("PageSize", "1");
+
+        return executePersonnelSearch(request);
+    }
+
     CCurePersonnel getPersonnelDetailsByEmail(String email) {
         MultipartBody request = Unirest.post(apiUrl + "/Objects/FindObjsWithCriteriaFilter")
                 .field("TypeFullName", CCurePersonnel.TYPE)
@@ -338,6 +359,7 @@ class CCureClient {
             return new CCurePersonnel(
                     id: responseObj.optInt("ObjectID"),
                     emailAddress: responseObj.optString("EmailAddress"),
+                    employeeId: responseObj.optString(employeeIdField),
                     partitionId: responseObj.optInt("PartitionID")
             );
         } else {

--- a/src/main/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureClient.groovy
+++ b/src/main/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureClient.groovy
@@ -67,6 +67,7 @@ class CCureClient {
         throwIfBlank(username, "The CCURE username for the api must be provided in CCureClient.username")
         throwIfBlank(password, "The CCURE password for the api must be provided in CCureClient.password")
         throwIfBlank(clientId, "The CCURE integration client ID must be provided in CCureClient.clientId")
+        throwIfBlank(employeeIdField, "The CCURE integration custom employee ID field name must be provided in CCureClient.employeeIdField")
         apiUrl = "$baseUrl/api"
 
         //CCURE docs say to space out all calls by 1-2 seconds to avoid rate limiting, so this will in enforce a 1

--- a/src/main/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureIntegrationStorageClient.groovy
+++ b/src/main/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureIntegrationStorageClient.groovy
@@ -10,6 +10,8 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
+import static com.cloudcard.photoDownloader.ApplicationPropertiesValidator.throwIfBlank
+
 @Component
 @ConditionalOnProperty(value = "IntegrationStorageService.client", havingValue = "CCureClient")
 class CCureIntegrationStorageClient implements IntegrationStorageClient {
@@ -28,6 +30,12 @@ class CCureIntegrationStorageClient implements IntegrationStorageClient {
     @Value('${CCureClient.createPersonnel:false}')
     boolean createCCurePersonnel
 
+    @Value('${CCureClient.createPersonnel.firstName}')
+    String firstNameField
+
+    @Value('${CCureClient.createPersonnel.lastName}')
+    String lastNameField
+
     @Value('${CCureClient.employeeIdField}')
     String employeeIdField
 
@@ -37,6 +45,10 @@ class CCureIntegrationStorageClient implements IntegrationStorageClient {
 
     @PostConstruct
     void init() {
+        if (createCCurePersonnel) {
+            throwIfBlank(firstNameField, "The custom field name for first name must be provided in CCureClient.createPersonnel.firstName")
+            throwIfBlank(lastNameField, "The custom field name for first name must be provided in CCureClient.createPersonnel.lastName")
+        }
         cCureClient.authenticate()
 
         cCureClient.queryAuditLogsForNewPeople().each {pushPhoto(it)}
@@ -103,7 +115,7 @@ class CCureIntegrationStorageClient implements IntegrationStorageClient {
             if (cCurePersonnel?.id) {
                 cCureClient.storePhoto(cCurePersonnel.id, photo.bytesBase64, cCurePersonnel.partitionId)
             } else if (createCCurePersonnel) {
-                Long id = cCureClient.createPersonnel(photo.person.customFields?.firstName, photo.person.customFields?.lastName, photo.person.email, identifier)
+                Long id = cCureClient.createPersonnel(photo.person.customFields?[firstNameField], photo.person.customFields?[lastNameField], photo.person.email, identifier)
                 if (!id) {
                     throw new FailedPhotoFileException("Unable to create CCURE personnel record for $photo.person.email")
                 }

--- a/src/main/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureIntegrationStorageClient.groovy
+++ b/src/main/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureIntegrationStorageClient.groovy
@@ -46,7 +46,8 @@ class CCureIntegrationStorageClient implements IntegrationStorageClient {
                 log.info("Received notification of personnel creation for ${payload.NotificationDSO.EmailAddress}");
                 CCurePersonnel newPersonnel = new CCurePersonnel(
                         id: payload.NotificationDSO.ObjectID,
-                        emailAddress: payload.NotificationDSO.EmailAddress
+                        emailAddress: payload.NotificationDSO.EmailAddress,
+                        employeeId: payload.NotificationDSO[employeeIdField]
                 )
                 pushPhoto(newPersonnel)
             }
@@ -67,35 +68,46 @@ class CCureIntegrationStorageClient implements IntegrationStorageClient {
     void pushPhoto(CCurePersonnel personnel) {
         // load person by email
         log.trace("Loading cloudcard record for $personnel.emailAddress")
-        Person cloudCardPerson = cloudCardClient.findPerson(personnel.emailAddress)
+        Person cloudCardPerson = findCloudCardPerson(personnel)
         if (cloudCardPerson?.additionalProperties?.currentPhoto) {
             log.trace "Person $personnel.emailAddress has a photo, sending to CCURE"
             Photo photo = cloudCardPerson.additionalProperties.currentPhoto as Photo
             if (Photo.APPROVED_STATUSES.contains(photo.status)) {
                 restService.fetchBytes(photo)
-                putPhoto(personnel.id as String, photo)
+                putPhoto(personnel.employeeId as String, photo)
             }
         } else if (!cloudCardPerson) {
             log.trace "$personnel.emailAddress does not exist in RemotePhoto, creating record there"
-            cloudCardClient.createPerson(personnel.emailAddress)
+            cloudCardClient.createPerson(personnel.emailAddress, personnel.employeeId)
         }
 
         lastRunPropertyService.updateLastRunTimestamp()
     }
 
+    Person findCloudCardPerson(CCurePersonnel personnel) {
+        Person cloudCardPerson = null
+        if (personnel.employeeId) {
+            cloudCardPerson = cloudCardClient.findPersonByIdentifier(personnel.employeeId)
+        }
+        if (!cloudCardPerson) {
+            cloudCardPerson = cloudCardClient.findPersonByEmail(personnel.emailAddress)
+        }
+
+        return cloudCardPerson
+    }
+
     @Override
     void putPhoto(String identifier, Photo photo) {
         try {
-            // CCURE won't use the local identifier, we need to look up their CCURE id
-            CCurePersonnel cCurePersonnel = cCureClient.getPersonnelDetailsByEmail(photo.person.email)
+            CCurePersonnel cCurePersonnel = cCureClient.getPersonnelDetails(identifier, photo.person.email)
             if (cCurePersonnel?.id) {
                 cCureClient.storePhoto(cCurePersonnel.id, photo.bytesBase64, cCurePersonnel.partitionId)
             } else if (createCCurePersonnel) {
-                Long id = cCureClient.createPersonnel(photo.person.customFields?.firstName, photo.person.customFields?.lastName, photo.person.email)
+                Long id = cCureClient.createPersonnel(photo.person.customFields?.firstName, photo.person.customFields?.lastName, photo.person.email, identifier)
                 if (!id) {
                     throw new FailedPhotoFileException("Unable to create CCURE personnel record for $photo.person.email")
                 }
-                cCurePersonnel = cCureClient.getPersonnelDetailsByEmail(photo.person.email)
+                cCurePersonnel = cCureClient.getPersonnelDetails(identifier, photo.person.email)
                 cCureClient.storePhoto(id, photo.bytesBase64, cCurePersonnel.partitionId)
             } else {
                 throw new FailedPhotoFileException("CCURE Personnel record not found for $photo.person.email")

--- a/src/main/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCurePersonnel.groovy
+++ b/src/main/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCurePersonnel.groovy
@@ -6,5 +6,6 @@ class CCurePersonnel {
 
     Long id
     String emailAddress
+    String employeeId
     Long partitionId
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -197,7 +197,7 @@ CCureClient.clientId=
 CCureClient.employeeIdField=
 # This should only be changed if the default timeout on the API has been changed from the default 30 minute timeout.
 CCureClient.keepAliveTime=1500000
-# Creating personnel records in CCURE will only use the person's first name, last name, and their email.
+# Creating personnel records in CCURE will only use the person's identifier, first name, last name, and their email.
 # First and Last name must be custom fields in RemotePhoto.
 CCureClient.createPersonnel=false
 CCureClient.createPersonnel.firstName=firstName

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -200,3 +200,5 @@ CCureClient.keepAliveTime=1500000
 # Creating personnel records in CCURE will only use the person's first name, last name, and their email.
 # First and Last name must be custom fields in RemotePhoto.
 CCureClient.createPersonnel=false
+CCureClient.createPersonnel.firstName=firstName
+CCureClient.createPersonnel.lastName=lastName

--- a/src/test/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureIntegrationStorageClientSpec.groovy
+++ b/src/test/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureIntegrationStorageClientSpec.groovy
@@ -132,6 +132,8 @@ class CCureIntegrationStorageClientSpec extends Specification {
         Person person = new Person(email: "test@example.com", customFields: [firstName: "John", lastName: "Doe"])
         Photo photo = new Photo(id: 1, person: person, bytes: "bytes")
         integrationClient.createCCurePersonnel = true
+        integrationClient.firstNameField = "firstName"
+        integrationClient.lastNameField = "lastName"
 
         when:
         integrationClient.putPhoto(identifier, photo)
@@ -149,6 +151,8 @@ class CCureIntegrationStorageClientSpec extends Specification {
         Person person = new Person(email: "test@example.com", customFields: [firstName: "John", lastName: "Doe"])
         Photo photo = new Photo(id: 1, person: person, bytes: "bytes")
         integrationClient.createCCurePersonnel = true
+        integrationClient.firstNameField = "firstName"
+        integrationClient.lastNameField = "lastName"
 
         when:
         integrationClient.putPhoto(identifier, photo)

--- a/src/test/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureIntegrationStorageClientSpec.groovy
+++ b/src/test/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureIntegrationStorageClientSpec.groovy
@@ -176,8 +176,8 @@ class CCureIntegrationStorageClientSpec extends Specification {
         integrationClient.putPhoto(identifier, photo)
 
         then:
-        1 * cCureClient.getPersonnelDetailsByEmail("test@example.com") >> null
-        1 * cCureClient.createPersonnel(null, null, "test@example.com") >> { throw new FailedPhotoFileException("Name fields are missing")}
+        1 * cCureClient.getPersonnelDetails(identifier, person.email) >> null
+        1 * cCureClient.createPersonnel(null, null, "test@example.com", identifier) >> { throw new FailedPhotoFileException("Name fields are missing")}
         0 * cCureClient.storePhoto(_, _)
         thrown(FailedPhotoFileException)
     }

--- a/src/test/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureIntegrationStorageClientSpec.groovy
+++ b/src/test/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureIntegrationStorageClientSpec.groovy
@@ -169,6 +169,8 @@ class CCureIntegrationStorageClientSpec extends Specification {
         Person person = new Person(email: "test@example.com", customFields: new HashMap<String, Object>())
         Photo photo = new Photo(id: 1, person: person, bytes: "bytes")
         integrationClient.createCCurePersonnel = true
+        integrationClient.firstNameField = "firstName"
+        integrationClient.lastNameField = "lastName"
 
         when:
         integrationClient.putPhoto(identifier, photo)
@@ -316,9 +318,11 @@ class CCureIntegrationStorageClientSpec extends Specification {
         given:
         def capturedCallback
         String identifier = "emp123"
-        Person person = new Person(email: "test@example.com", customFields: [firstName: "John", lastName: "Doe"])
+        Person person = new Person(identifier: identifier, email: "test@example.com", customFields: [firstName: "John", lastName: "Doe"])
         Photo photo = new Photo(id: 1, person: person, bytes: "bytes")
         integrationClient.createCCurePersonnel = true
+        integrationClient.firstNameField = "firstName"
+        integrationClient.lastNameField = "lastName"
 
         when:
         integrationClient.init()
@@ -335,9 +339,9 @@ class CCureIntegrationStorageClientSpec extends Specification {
         integrationClient.putPhoto(identifier, photo)
 
         then:
-        1 * cCureClient.getPersonnelDetailsByEmail("test@example.com") >> null
-        1 * cCureClient.createPersonnel("John", "Doe", "test@example.com") >> 789L
-        1 * cCureClient.getPersonnelDetailsByEmail("test@example.com") >> new CCurePersonnel(id: 789L, emailAddress: "test@example.com", partitionId: 1)
+        1 * cCureClient.getPersonnelDetails(person.identifier, person.email) >> null
+        1 * cCureClient.createPersonnel("John", "Doe", person.email, person.identifier) >> 789L
+        1 * cCureClient.getPersonnelDetails(identifier, person.email) >> new CCurePersonnel(id: 789L, emailAddress: person.email, partitionId: 1, employeeId: identifier)
         1 * cCureClient.storePhoto(789L, encodedBytes, 1)
         integrationClient.personnelJustCreated.size() == 1
 

--- a/src/test/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureIntegrationStorageClientSpec.groovy
+++ b/src/test/groovy/com/cloudcard/photoDownloader/storage/integration/ccure/CCureIntegrationStorageClientSpec.groovy
@@ -20,7 +20,7 @@ class CCureIntegrationStorageClientSpec extends Specification {
         integrationClient.restService = Mock(RestService)
         integrationClient.lastRunPropertyService = Mock(LastRunPropertyService)
         integrationClient.createCCurePersonnel = false
-        integrationClient.employeeIdField = "employeeId"
+        integrationClient.employeeIdField = "Text1"
 
         cCureClient = integrationClient.cCureClient
         cloudCardClient = integrationClient.cloudCardClient
@@ -42,9 +42,9 @@ class CCureIntegrationStorageClientSpec extends Specification {
         integrationClient.pushPhoto(personnel)
 
         then:
-        1 * cloudCardClient.findPerson("test@example.com") >> person
+        1 * cloudCardClient.findPersonByEmail("test@example.com") >> person
         1 * restService.fetchBytes(photo)
-        1 * cCureClient.getPersonnelDetailsByEmail("test@example.com") >> personnel
+        1 * cCureClient.getPersonnelDetails(null, person.email) >> personnel
         1 * cCureClient.storePhoto(personnel.id, encodedBytes, 1)
         1 * lastRunPropertyService.updateLastRunTimestamp()
     }
@@ -62,7 +62,7 @@ class CCureIntegrationStorageClientSpec extends Specification {
         integrationClient.pushPhoto(personnel)
 
         then:
-        1 * cloudCardClient.findPerson("test@example.com") >> person
+        1 * cloudCardClient.findPersonByEmail("test@example.com") >> person
         0 * restService.fetchBytes(_)
         0 * cCureClient.storePhoto(_, _)
         1 * lastRunPropertyService.updateLastRunTimestamp()
@@ -70,14 +70,14 @@ class CCureIntegrationStorageClientSpec extends Specification {
 
     def "test pushPhoto creates CloudCard person when none exists"() {
         given:
-        CCurePersonnel personnel = new CCurePersonnel(id: 123L, emailAddress: "test@example.com", partitionId: 1)
+        CCurePersonnel personnel = new CCurePersonnel(id: 123L, emailAddress: "test@example.com", partitionId: 1, employeeId: "emp123")
 
         when:
         integrationClient.pushPhoto(personnel)
 
         then:
-        1 * cloudCardClient.findPerson("test@example.com") >> null
-        1 * cloudCardClient.createPerson("test@example.com")
+        1 * cloudCardClient.findPersonByEmail("test@example.com") >> null
+        1 * cloudCardClient.createPerson(personnel.emailAddress, personnel.employeeId)
         1 * lastRunPropertyService.updateLastRunTimestamp()
     }
 
@@ -90,7 +90,7 @@ class CCureIntegrationStorageClientSpec extends Specification {
         integrationClient.pushPhoto(personnel)
 
         then:
-        1 * cloudCardClient.findPerson("test@example.com") >> person
+        1 * cloudCardClient.findPersonByEmail(person.email) >> person
         0 * cloudCardClient.createPerson(_)
         1 * lastRunPropertyService.updateLastRunTimestamp()
     }
@@ -106,7 +106,7 @@ class CCureIntegrationStorageClientSpec extends Specification {
         integrationClient.putPhoto(identifier, photo)
 
         then:
-        1 * cCureClient.getPersonnelDetailsByEmail("test@example.com") >> personnel
+        1 * cCureClient.getPersonnelDetails(identifier, person.email) >> personnel
         1 * cCureClient.storePhoto(456L, encodedBytes, 1)
     }
 
@@ -121,8 +121,8 @@ class CCureIntegrationStorageClientSpec extends Specification {
         integrationClient.putPhoto(identifier, photo)
 
         then:
-        1 * cCureClient.getPersonnelDetailsByEmail("test@example.com") >> null
-        0 * cCureClient.createPersonnel(_, _, _)
+        1 * cCureClient.getPersonnelDetails(identifier, person.email) >> null
+        0 * cCureClient.createPersonnel(_, _, _, _)
         thrown(FailedPhotoFileException)
     }
 
@@ -137,9 +137,9 @@ class CCureIntegrationStorageClientSpec extends Specification {
         integrationClient.putPhoto(identifier, photo)
 
         then:
-        1 * cCureClient.getPersonnelDetailsByEmail("test@example.com") >> null
-        1 * cCureClient.createPersonnel("John", "Doe", "test@example.com") >> 789L
-        1 * cCureClient.getPersonnelDetailsByEmail("test@example.com") >> new CCurePersonnel(id: 789L, emailAddress: "test@example.com", partitionId: 1)
+        1 * cCureClient.getPersonnelDetails(identifier, person.email) >> null
+        1 * cCureClient.createPersonnel("John", "Doe", person.email, identifier) >> 789L
+        1 * cCureClient.getPersonnelDetails(identifier, person.email) >> new CCurePersonnel(id: 789L, emailAddress: "test@example.com", partitionId: 1)
         1 * cCureClient.storePhoto(789L, encodedBytes, 1)
     }
 
@@ -154,8 +154,8 @@ class CCureIntegrationStorageClientSpec extends Specification {
         integrationClient.putPhoto(identifier, photo)
 
         then:
-        1 * cCureClient.getPersonnelDetailsByEmail("test@example.com") >> null
-        1 * cCureClient.createPersonnel("John", "Doe", "test@example.com") >> null
+        1 * cCureClient.getPersonnelDetails(identifier, person.email) >> null
+        1 * cCureClient.createPersonnel("John", "Doe", person.email, identifier) >> null
         0 * cCureClient.storePhoto(_, _)
         thrown(FailedPhotoFileException)
     }
@@ -172,7 +172,7 @@ class CCureIntegrationStorageClientSpec extends Specification {
         integrationClient.putPhoto(identifier, photo)
 
         then:
-        1 * cCureClient.getPersonnelDetailsByEmail("test@example.com") >> personnel
+        1 * cCureClient.getPersonnelDetails(identifier, person.email) >> personnel
         0 * cCureClient.storePhoto(_, _)
         thrown(FailedPhotoFileException)
     }
@@ -187,7 +187,7 @@ class CCureIntegrationStorageClientSpec extends Specification {
         integrationClient.putPhoto(identifier, photo)
 
         then:
-        1 * cCureClient.getPersonnelDetailsByEmail("test@example.com") >> { throw new RuntimeException("Network error") }
+        1 * cCureClient.getPersonnelDetails(identifier, person.email) >> { throw new RuntimeException("Network error") }
         thrown(FailedPhotoFileException)
     }
 
@@ -201,7 +201,7 @@ class CCureIntegrationStorageClientSpec extends Specification {
         integrationClient.putPhoto(identifier, photo)
 
         then:
-        1 * cCureClient.getPersonnelDetailsByEmail("test@example.com") >> { throw new FailedPhotoFileException("Already a FailedPhotoFileException") }
+        1 * cCureClient.getPersonnelDetails(identifier, person.email) >> { throw new FailedPhotoFileException("Already a FailedPhotoFileException") }
         def exception = thrown(FailedPhotoFileException)
         exception.message == "Already a FailedPhotoFileException"
     }
@@ -216,8 +216,8 @@ class CCureIntegrationStorageClientSpec extends Specification {
 
     def "test init authenticates and processes audit logs"() {
         given:
-        CCurePersonnel personnel1 = new CCurePersonnel(id: 1L, emailAddress: "user1@example.com", partitionId: 1)
-        CCurePersonnel personnel2 = new CCurePersonnel(id: 2L, emailAddress: "user2@example.com", partitionId: 1)
+        CCurePersonnel personnel1 = new CCurePersonnel(id: 1L, emailAddress: "user1@example.com", partitionId: 1, employeeId: "emp123")
+        CCurePersonnel personnel2 = new CCurePersonnel(id: 2L, emailAddress: "user2@example.com", partitionId: 1, employeeId: "emp456")
         List<CCurePersonnel> auditLogs = [personnel1, personnel2]
 
         when:
@@ -226,8 +226,8 @@ class CCureIntegrationStorageClientSpec extends Specification {
         then:
         1 * cCureClient.authenticate()
         1 * cCureClient.queryAuditLogsForNewPeople() >> auditLogs
-        2 * cloudCardClient.findPerson(_) >> null
-        2 * cloudCardClient.createPerson(_)
+        2 * cloudCardClient.findPersonByEmail(_) >> null
+        2 * cloudCardClient.createPerson(_, _)
         1 * cCureClient.subscribeForNewEvents(_)
         2 * lastRunPropertyService.updateLastRunTimestamp()
     }
@@ -251,14 +251,15 @@ class CCureIntegrationStorageClientSpec extends Specification {
             NotificationType: "ObjectCreated",
             NotificationDSO: [
                 ObjectID: 999L,
-                EmailAddress: "newuser@example.com"
+                EmailAddress: "newuser@example.com",
+                "Text1": "emp123"
             ]
         ]
         capturedCallback(payload)
 
         then:
-        1 * cloudCardClient.findPerson("newuser@example.com") >> null
-        1 * cloudCardClient.createPerson("newuser@example.com")
+        1 * cloudCardClient.findPersonByEmail("newuser@example.com") >> null
+        1 * cloudCardClient.createPerson("newuser@example.com", "emp123")
         1 * lastRunPropertyService.updateLastRunTimestamp()
     }
 
@@ -281,14 +282,15 @@ class CCureIntegrationStorageClientSpec extends Specification {
             NotificationType: "ObjectModified",
             NotificationDSO: [
                 ObjectID: 999L,
-                EmailAddress: "user@example.com"
+                EmailAddress: "user@example.com",
+                Text1: "emp123"
             ]
         ]
         capturedCallback(payload)
 
         then:
-        0 * cloudCardClient.findPerson(_)
-        0 * cloudCardClient.createPerson(_)
+        0 * cloudCardClient.findPersonByEmail(_)
+        0 * cloudCardClient.createPerson(_, _)
         0 * lastRunPropertyService.updateLastRunTimestamp()
     }
 }


### PR DESCRIPTION
This expands the field mappings on the CCURE integration by adding the following:

- Requires the employeeIdField property to be set. This will indicate which custom data field in CCURE is going to hold the employee's id. (Or whatever we have in the RP identifier field.)
- I refer to it as employeeId so that it's not confused with internal system identifiers, but maybe there's a better name?
- We then use that as a primary match field before email when comparing CCURE and RP records, and push the field to the other system when we create a record.
- Similarly, this allows the configuration of RP customField names for first and last name when we need to create personnel in CCURE.