### PR TITLE
Sending logs from the downloader to the API so they get captured by Papertrail

### DIFF
--- a/src/main/groovy/com/cloudcard/photoDownloader/CloudCardClient.groovy
+++ b/src/main/groovy/com/cloudcard/photoDownloader/CloudCardClient.groovy
@@ -2,6 +2,8 @@ package com.cloudcard.photoDownloader
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
+import groovy.json.JsonOutput
+import kong.unirest.core.Empty
 import kong.unirest.core.HttpResponse
 import kong.unirest.core.Unirest
 import org.slf4j.Logger
@@ -110,6 +112,21 @@ class CloudCardClient {
 
         return new ObjectMapper().readValue(response.getBody(), new TypeReference<List<Photo>>() {
         })
+    }
+
+    void remoteLog(List<String> logs) throws Exception {
+        String url = "${apiUrl}/logs"
+        def payload = [logs: logs]
+
+        HttpResponse<Empty> response = Unirest.post(url)
+            .headers(standardHeaders())
+            .body(JsonOutput.toJson(payload))
+            .asEmpty()
+
+        if (response.status != 204) {
+            //Avoid using log methods here!
+            System.err.println("Status ${response.status} returned from CloudCard API when attempting to post logs.")
+        }
     }
 
     void close() {

--- a/src/main/groovy/com/cloudcard/photoDownloader/DatabasePostProcessor.java
+++ b/src/main/groovy/com/cloudcard/photoDownloader/DatabasePostProcessor.java
@@ -58,8 +58,7 @@ public class DatabasePostProcessor implements PostProcessor {
             updateDatabase(photo, photoFile);
             return photoFile;
         } catch (Exception e) {
-            log.error("Post processing failed: " + e.getMessage() + "\nPrint stacktrace follows...");
-            e.printStackTrace();
+            log.error("Post processing failed: " + e.getMessage() + "\nPrint stacktrace follows...", e);
             return null;
         }
     }

--- a/src/main/groovy/com/cloudcard/photoDownloader/DatabaseStorageService.java
+++ b/src/main/groovy/com/cloudcard/photoDownloader/DatabaseStorageService.java
@@ -93,8 +93,7 @@ public class DatabaseStorageService implements StorageService {
 
             return new PhotoFile(photo.getPerson().getIdentifier(), null, photo.getId());
         } catch (Exception e) {
-            log.error("Failed to push photo" + photo.getId() + " to DB.");
-            e.printStackTrace();
+            log.error("Failed to push photo" + photo.getId() + " to DB.", e);
             return null;
         }
     }

--- a/src/main/groovy/com/cloudcard/photoDownloader/DownloaderService.java
+++ b/src/main/groovy/com/cloudcard/photoDownloader/DownloaderService.java
@@ -112,8 +112,7 @@ public class DownloaderService {
 
         } catch (Exception e) {
 
-            log.error(e.getMessage());
-            e.printStackTrace();
+            log.error(e.getMessage(), e);
             exitStatus = 1;
 
         } finally {

--- a/src/main/groovy/com/cloudcard/photoDownloader/IntegrationStorageService.groovy
+++ b/src/main/groovy/com/cloudcard/photoDownloader/IntegrationStorageService.groovy
@@ -72,8 +72,7 @@ class IntegrationStorageService implements StorageService {
             throw failedPhotoFileException
         } catch (Exception e) {
             log.error("Photo $photo.id for $photo.person.email failed to upload into ${integrationStorageClient.systemName}.")
-            log.error(e.message)
-            e.printStackTrace()
+            log.error(e.message, e)
             return null
         }
 

--- a/src/main/groovy/com/cloudcard/photoDownloader/RemoteLoggingAppender.groovy
+++ b/src/main/groovy/com/cloudcard/photoDownloader/RemoteLoggingAppender.groovy
@@ -1,0 +1,84 @@
+package com.cloudcard.photoDownloader
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.spi.IThrowableProxy
+import ch.qos.logback.classic.spi.ThrowableProxyUtil
+import ch.qos.logback.core.AppenderBase
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+
+/**
+ * This will allow error logs to be posted to the RemotePhoto API, either every 60 seconds or once the batch size reaches
+ * 100 messages.
+ *
+ * DO NOT use any log methods here to prevent infinite looping (stick to System.out/err)
+ */
+class RemoteLoggingAppender extends AppenderBase<ILoggingEvent> {
+
+    ConcurrentLinkedQueue<String> logQueue = new ConcurrentLinkedQueue<>()
+    private final int BATCH_SIZE = 100;
+    private final long MAX_DELAY_MS = 60000;
+    private ScheduledExecutorService scheduler;
+
+    @Override
+    void start() {
+        super.start();
+        // Start a background timer to flush logs even if BATCH_SIZE isn't reached
+        scheduler = Executors.newSingleThreadScheduledExecutor();
+        scheduler.scheduleWithFixedDelay(this::flush, MAX_DELAY_MS, MAX_DELAY_MS, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    protected void append(ILoggingEvent eventObject) {
+        if (eventObject.level == Level.ERROR) {
+            StringBuilder fullMessage = new StringBuilder(eventObject.getFormattedMessage());
+
+            // Check if there is an associated exception (Throwable)
+            IThrowableProxy throwableProxy = eventObject.getThrowableProxy();
+            if (throwableProxy != null) {
+                // Convert the proxy into a full stack trace string
+                String stackTrace = ThrowableProxyUtil.asString(throwableProxy);
+                fullMessage.append(System.lineSeparator()).append(stackTrace);
+            }
+
+            logQueue << fullMessage.toString()
+
+            if (logQueue.size() >= BATCH_SIZE) {
+                flush();
+            }
+        }
+    }
+
+    private synchronized void flush() {
+        if (logQueue.isEmpty()) return;
+
+        List<String> toSend = new ArrayList<>(logQueue);
+        logQueue.clear();
+
+        // Perform the network call to your remote service
+        sendToRemoteService(toSend);
+    }
+
+    private void sendToRemoteService(List<String> events) {
+        try {
+            CloudCardClient client = SpringContextBridge.getBean(CloudCardClient.class)
+            println("Sending batch of " + events.size() + " logs to remote service.");
+            client.remoteLog(events)
+        } catch (Exception ex) {
+            System.err.println("Failed to load CloudCardClient from the context: ${ex.localizedMessage}")
+            //clear the queue to prevent recurring problems if we get here
+            logQueue.clear()
+        }
+    }
+
+    @Override
+    void stop() {
+        flush(); // Final attempt to send remaining logs
+        scheduler.shutdown();
+        super.stop();
+    }
+}

--- a/src/main/groovy/com/cloudcard/photoDownloader/SchedulerConfig.java
+++ b/src/main/groovy/com/cloudcard/photoDownloader/SchedulerConfig.java
@@ -1,0 +1,18 @@
+package com.cloudcard.photoDownloader;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5);
+        scheduler.setThreadNamePrefix("ScheduledTask-");
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/src/main/groovy/com/cloudcard/photoDownloader/ShellCommandRunner.java
+++ b/src/main/groovy/com/cloudcard/photoDownloader/ShellCommandRunner.java
@@ -35,10 +35,8 @@ public class ShellCommandRunner {
                 log.error(command + " exited with error code: " + exitCode);
             return exitCode == 0;
 
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (InterruptedException e) {
-            e.printStackTrace();
+        } catch (IOException | InterruptedException e) {
+            log.error("Exception occurred during run:", e);
         }
 
         return false;

--- a/src/main/groovy/com/cloudcard/photoDownloader/SpringContextBridge.groovy
+++ b/src/main/groovy/com/cloudcard/photoDownloader/SpringContextBridge.groovy
@@ -1,0 +1,25 @@
+package com.cloudcard.photoDownloader
+
+import org.springframework.beans.BeansException
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationContextAware
+import org.springframework.stereotype.Component
+
+@Component
+class SpringContextBridge implements ApplicationContextAware {
+    private static ApplicationContext context;
+
+    @Override
+    void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        context = applicationContext;
+    }
+
+    /**
+     * This allows us to pull beans from the context into classes that can't be context-aware, like the logging appender.
+     * @param beanClass The type of the component bean you want to retrieve
+     * @return The Spring-managed component from the context that matches the specified class
+     */
+    static <T> T getBean(Class<T> beanClass) {
+        return context.getBean(beanClass);
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -37,9 +37,21 @@
         </then>
 
         <else>
+            <!-- Only activate the remote logging when we aren't already logging directly to Papertrail -->
+            <appender name="REMOTE" class="com.cloudcard.photoDownloader.RemoteLoggingAppender" />
+
+            <appender name="ASYNC_REMOTE" class="ch.qos.logback.classic.AsyncAppender">
+                <appender-ref ref="REMOTE" />
+                <queueSize>100</queueSize>
+                <discardingThreshold>0</discardingThreshold>
+                <neverBlock>true</neverBlock>
+            </appender>
+
             <root level="INFO">
                 <appender-ref ref="STDOUT"/>
+                <appender-ref ref="ASYNC_REMOTE" />
             </root>
+
         </else>
     </if>
 </configuration>


### PR DESCRIPTION
Updated downloader to catch error logs and send them to the API for logging using a custom logging appender. 
Removed calls to printStackTrace and just included the exception in the log.error calls.